### PR TITLE
Focus the search field on default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # MeeSpot specific stuff
 libspotify/*/*
 libspotify/*
+libspotify_emu/*
 MeeSpot
 *.deb
 *.changes

--- a/qml/SearchPage.qml
+++ b/qml/SearchPage.qml
@@ -27,6 +27,7 @@ Page {
 
             SearchField {
                 id: searchField
+                focus: true
                 placeholderText: qsTr("Search")
                 width: parent.width
                 inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText


### PR DESCRIPTION
When opening the search page, give the search field focus on default.
